### PR TITLE
chore: Update Node version from 20 to 24 in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ outputs:
   output:
     description: Output from the jq command
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'
 branding:
   icon: chevron-right


### PR DESCRIPTION
## what
* Update Node version from 20 to 24 in action.yml

## why
Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## references
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/