### PR TITLE
chore: Update Node version from 20 to 24 in action.yml (#19)

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -5,4 +5,3 @@ repository:
   description: Process a value with a jq script and output to a step output.
   homepage: https://cloudposse.com/accelerate
   topics: ""
-

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -8,4 +8,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,8 @@ on:
       sha:
         description: "The sha of the commit that triggered the workflow run"
         required: false
-        type: "string"  pull_request:
+        type: "string"  
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
       sha:
         description: "The sha of the commit that triggered the workflow run"
         required: false
-        type: "string"  
+        type: "string"
   pull_request:
   push:
     branches:

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ outputs:
   output:
     description: Output from the jq command
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'
 branding:
   icon: chevron-right


### PR DESCRIPTION
## what
* Update Node version from 20 to 24 in action.yml

## why
Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## references
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
https://github.com/cloudposse/github-action-jq/pull/19